### PR TITLE
додає правки в код .slogan

### DIFF
--- a/src/sass/base/_common.scss
+++ b/src/sass/base/_common.scss
@@ -117,26 +117,22 @@ p {
 }
 
 .slogan {
-  margin-left: 80px;
+  display: flex;
+  align-items: center;
+
   font-weight: 600;
   font-size: 11px;
   line-height: 1.36;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-
   color: $title-text-color;
 
-  position: relative;
-
   &::before {
-    display: block;
     content: '';
-    position: absolute;
-    bottom: 50%;
-    right: 60px;
-
+    margin-right: 20px;
     width: 60px;
     height: 1px;
+
     background-color: $title-text-color;
   }
 }


### PR DESCRIPTION
Обговорення в Слак https://fecore22online.slack.com/archives/G016RDHNKBN/p1594332633056400

Зіштовхнувся з тим, що стилі для .slogan не підійшли для секції Наши мастера  https://prnt.sc/tezw1w
В той час як для секції О нас https://prnt.sc/tezwnq все ок
Гадаю справа в https://prnt.sc/tezyed
і пропоную внести наступні правки в код
Протестував https://prnt.sc/tf024w, ніби норм вийшло, підходить під будь яку ширину Слогану https://prnt.sc/tf030m